### PR TITLE
Fix link on token.md - points to create new app

### DIFF
--- a/v1/authentication/token.md
+++ b/v1/authentication/token.md
@@ -1,13 +1,13 @@
 # Obtain access token
 
-External applications could obtain a user authorized API token via the OAuth2 protocol. Before getting started, developers need to create their applications in [App Management Console](https://app.raindrop.io/#/settings/apps/dev) and configure a valid OAuth redirect URL. A registered Raindrop.io application is assigned a unique `Client ID` and `Client Secret` which are needed for the OAuth2 flow.
+External applications could obtain a user authorized API token via the OAuth2 protocol. Before getting started, developers need to create their applications in [App Management Console](https://app.raindrop.io/settings/integrations) and configure a valid OAuth redirect URL. A registered Raindrop.io application is assigned a unique `Client ID` and `Client Secret` which are needed for the OAuth2 flow.
 
 This procedure is comprised of several steps, which will be described below.
 
 {% hint style="info" %}
 If you just want to test your application, or do not plan to access any data except yours account you don't need to make all of those steps.
 
-Just go to [App Management Console](https://app.raindrop.io/#/settings/apps/dev) and open your application settings. Copy **Test token** and use it as described in **Step 4.**
+Just go to [App Management Console](https://app.raindrop.io/settings/integrations) and open your application settings. Copy **Test token** and use it as described in **Step 4.**
 {% endhint %}
 
 {% api-method method="get" host="https://raindrop.io" path="/oauth/authorize" %}


### PR DESCRIPTION
https://app.raindrop.io/#/settings/apps/dev
is a dead link that brings you to the apps page with no content for managing apps.


https://app.raindrop.io/settings/integrations
the content on this page includes a "for developers" section where you can create new apps.

I believe there are other pages that have this issue as well.