### PR TITLE
Fix integrations link on authentication page

### DIFF
--- a/v1/authentication/README.md
+++ b/v1/authentication/README.md
@@ -2,6 +2,6 @@
 
 In order to make authorized calls to Raindrop.io API, you must do the following:
 
-* [x] [Register your application](https://app.raindrop.io/#/settings/apps/dev)
+* [x] [Register your application](https://app.raindrop.io/settings/integrations)
 * [x] [Obtain access token](token.md)
 


### PR DESCRIPTION
As with #6, the link on the authentication page points to a dead link (`https://app.raindrop.io/#/settings/apps/dev`).

This PR updates the link to https://app.raindrop.io/settings/integrations

Thanks for making raindrop and putting it out for free and as open source!