### PR TITLE
Update link to MCP docs for client configuration

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -30,4 +30,4 @@ You can also use the same access token as with the [REST API](../v1/authenticati
 
 ## Client Configuration
 
-For step-by-step setup instructions for Claude, ChatGPT, VS Code, Cursor, and other clients, see the [Raindrop.io Help Center](https://help.raindrop.io/mcp).
+For step-by-step setup instructions for Claude, ChatGPT, VS Code, Cursor, and other clients, see the [Raindrop.io Help Center](https://help.raindrop.io/integrations/mcp).


### PR DESCRIPTION
The previous link takes us to (what looks like) an MCP server config.
This change swaps it out for the MCP Server docs in the Help Center
where there's actual per-client docs for connecting tot he server
